### PR TITLE
【change】 TailwindcssがRenderでbuildされるように修正した

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
+web: bin/rails server -p 3000
 js: yarn build --watch
 css: yarn build:css --watch

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,6 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
-    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,6 +3,9 @@
 set -o errexit
 
 bundle install
+yarn install
+yarn build:css
+yarn build
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate


### PR DESCRIPTION
### 概要
Renderのデプロイ時にTailwindcssがビルドされなかったのでビルドされる記述を追加しました。

### 作業内容
- bin/render-build.shにyarn install、yarn build:css、yarn buildを追記
- Procfile.devにbin/dev を実行したら Railsサーバーが起動するようにwebの記述を追記
- application.html.erbのstylesheet_link_tag "tailwind"を削除
