### PR TITLE
【feature】ヘッダーの部分テンプレートを作成#7

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,8 +18,21 @@
   </head>
 
   <body class="bg-base-100 min-h-screen font-mplus">
-  <%= render 'shared/header' %>
-  <%= yield %>
-</body>
-
+    <!-- ドロワー全体を囲む -->
+    <div class="drawer">
+      <!-- チェックボックス（非表示） -->
+      <input id="drawer-menu" type="checkbox" class="drawer-toggle" />
+      <!-- メインコンテンツエリア -->
+      <div class="drawer-content">
+        <!-- ヘッダーの出し分け -->
+        <%= render 'shared/before_login_header' %>
+        <!-- 各ページの内容 -->
+        <main class="container mx-auto px-4 py-8">
+          <%= yield %>
+        </main>
+      </div>
+      <!-- ドロワーメニューの出し分け -->
+      <%= render 'shared/before_login_drawer_menu' %>
+    </div>
+  </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
   </head>
 
   <body class="bg-base-100 min-h-screen font-mplus">
+  <%= render 'shared/header' %>
   <%= yield %>
 </body>
 

--- a/app/views/shared/_before_login_drawer_menu.html.erb
+++ b/app/views/shared/_before_login_drawer_menu.html.erb
@@ -1,0 +1,7 @@
+<div class="drawer-side">
+  <label for="drawer-menu" class="drawer-overlay"></label>
+  <ul class="menu p-4 w-80 bg-base-100">
+    <li><%= link_to '利用規約', "#" %></li>
+    <li><%= link_to 'プライバシーポリシー', "#" %></li>
+  </ul>
+</div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,0 +1,15 @@
+<header class="navbar bg-primary text-primary-content px-4">
+  <!-- Hamburger -->
+  <label for="drawer-menu" class="btn btn-ghost btn-sm drawer-button">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+        stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+      <path stroke-linecap="round" stroke-linejoin="round"
+        d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
+    </svg>
+  </label>
+
+  <!-- Center Title -->
+  <div class="mx-auto text-center">
+    <span class="text-lg font-bold tracking-wider">OKAN</span>
+  </div>
+</header>

--- a/app/views/shared/_drawer_menu.html.erb
+++ b/app/views/shared/_drawer_menu.html.erb
@@ -1,0 +1,7 @@
+<div class="drawer-side">
+  <label for="drawer-menu" class="drawer-overlay"></label>
+    <ul class="menu p-4 w-80 bg-base-100">
+      <li><%= link_to '登録薬一覧', "#" %></li>
+      <li><%= link_to '残薬一覧', "#" %></li>
+    </ul>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,15 @@
+<header class="navbar bg-primary text-primary-content px-4">
+      <!-- Hamburger -->
+      <label for="drawer-menu" class="btn btn-ghost btn-sm drawer-button">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+             stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round"
+                d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
+        </svg>
+      </label>
+
+      <!-- Center Title -->
+      <div class="mx-auto text-center">
+        <span class="text-lg font-bold tracking-wider">OKAN</span>
+      </div>
+    </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,15 +1,15 @@
 <header class="navbar bg-primary text-primary-content px-4">
-      <!-- Hamburger -->
-      <label for="drawer-menu" class="btn btn-ghost btn-sm drawer-button">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-             stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-          <path stroke-linecap="round" stroke-linejoin="round"
-                d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
-        </svg>
-      </label>
+  <!-- Hamburger -->
+  <label for="drawer-menu" class="btn btn-ghost btn-sm drawer-button">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+        stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+      <path stroke-linecap="round" stroke-linejoin="round"
+        d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
+    </svg>
+  </label>
 
-      <!-- Center Title -->
-      <div class="mx-auto text-center">
-        <span class="text-lg font-bold tracking-wider">OKAN</span>
-      </div>
-    </header>
+  <!-- Center Title -->
+  <div class="mx-auto text-center">
+    <span class="text-lg font-bold tracking-wider">OKAN</span>
+  </div>
+</header>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -2,23 +2,6 @@
   <input id="drawer-menu" type="checkbox" class="drawer-toggle" />
   <div class="drawer-content">
 
-    <!-- Header -->
-    <header class="navbar bg-primary text-primary-content px-4">
-      <!-- Hamburger -->
-      <label for="drawer-menu" class="btn btn-ghost btn-sm drawer-button">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-             stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-          <path stroke-linecap="round" stroke-linejoin="round"
-                d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
-        </svg>
-      </label>
-
-      <!-- Center Title -->
-      <div class="mx-auto text-center">
-        <span class="text-lg font-bold tracking-wider">OKAN</span>
-      </div>
-    </header>
-
     <!-- Body -->
     <main class="flex flex-col items-center justify-center mt-40 px-6 space-y-5">
 

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -4,21 +4,10 @@
 
     <!-- Body -->
     <main class="flex flex-col items-center justify-center mt-40 px-6 space-y-5">
-
       <%= link_to "新規登録", "#",
           class: "btn btn-primary w-full max-w-xs" %>
       <%= link_to "ログイン","#",
           class: "btn bg-white text-[#E56A54] border border-[#E56A54] hover:bg-[#FFE4DF] w-full max-w-xs" %>
-
     </main>
-  </div>
-
-  <!-- Drawer Menu (まだ中身なし) -->
-  <div class="drawer-side">
-    <label for="drawer-menu" class="drawer-overlay"></label>
-    <ul class="menu p-4 w-60 min-h-full bg-base-100 text-base-content">
-      <li><%= link_to '登録薬一覧', "#" %></li>
-      <li><%= link_to '残薬一覧', "#" %></li>
-    </ul>
   </div>
 </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -16,8 +16,9 @@
   <!-- Drawer Menu (まだ中身なし) -->
   <div class="drawer-side">
     <label for="drawer-menu" class="drawer-overlay"></label>
-    <ul class="menu p-4 w-60 min-h-full bg-base-200 text-base-content">
-      <li class="text-sm text-gray-600">メニュー準備中…</li>
+    <ul class="menu p-4 w-60 min-h-full bg-base-100 text-base-content">
+      <li><%= link_to '登録薬一覧', "#" %></li>
+      <li><%= link_to '残薬一覧', "#" %></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
### 概要
ヘッダーをログイン前とログイン後に分けて部分テンプレートに切り出しました。

### 作業内容
ログイン前
- _before_login_header.html.erbにハンバーガーメニューとOKANのロゴを表示する記述
- _before_login_drawer_menu.html.erbにハンバーガーメニューを開いたときの内容を記述（利用規約、プライバシーポリシー）
ログイン後
- _header.html.erbにハンバーガーメニューとOKANのロゴを表示する記述
- _drawer.menu.html.erbにハンバーガーメニューを開いたときの内容を記述（登録薬一覧、残薬一覧）
- applocation.html.erbにログイン前のヘッダーの表示を記述

### 機能追加理由
ヘッダーを部分テンプレートに分けることで複数箇所で効率よく記述できるようにするため。

### 備考
ログイン機能は未実装のためapplocation.html.erbに条件分岐はまだ書いていません。
利用規約とプライバシーポリシーはMVPに含めないためリンク先には遷移しません。